### PR TITLE
Added async keyword to queryItems

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ docClient.query(params, function(err, data) {
 });
 
 // async function abstraction
-function queryItems(type){
+async function queryItems(type){
   var params = {
     TableName: 'ProductTable',
     IndexName: 'type-index',


### PR DESCRIPTION
This function with `await` fails without the async keyword. 

Thanks again for creating this resource!