### PR TITLE
Update remainder in batchWrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,7 +358,7 @@ const seedData = fetchedData.map((item) => {
   */
 
 let quotient = Math.floor(seedData.length / 25)
-const remainder = (seedData.length % 25) + 1
+const remainder = (seedData.length % 25)
 
 /* Upload in increments of 25 */
 


### PR DESCRIPTION
Whilst using the `batchWrite` as the code is specified I noticed unexpected behavior.
It looks slicing of the remaining seedData is one of.

My reasoning goes as follows.  
Assume the following example:
- suppose `fetchedData` has length 3
- `seedData` then also has length 3
- since 3 < 25 the quotiënt will evaluate to 0
- according to the previous implementation `const remainder = (seedData.length % 25) + 1`, the remainder will be 4 (3 % 25 + 1 )
- This will slice `seedData`: `seedData.slice(3 - 4)` -> `seedData.slice(-1)`
Which will only slice the last item of `seedData` leaving the first 2 untouched.
- Thereby not executing the first 2 requests that should be made.

If my story adds up, chaning to `const remainder = (seedData.length % 25)`, will mitigate the problem.
- This will slice `seedData`: `seedData.slice(3 - 3)` -> `seedData.slice(0)`
Which will slice right before the first not-executed request.
- The same reasoning can be made when fetchedData has a length of eg. 28 instead of 3. 

What do you think?
