### PR TITLE
update batchWrite:

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,7 +365,7 @@ const remainder = (seedData.length % 25) + 1
 let batchMultiplier = 1
 while (quotient > 0) {
   for (let i = 0; i < seedData.length - 1; i += 25) {
-    docClient.batchWrite(
+    await docClient.batchWrite(
       {
         RequestItems: {
           YOUR_TABLE_NAME: seedData.slice(i, 25 * batchMultiplier),
@@ -378,26 +378,28 @@ while (quotient > 0) {
           console.log('yay...uploaded!')
         }
       }
-    )
+    ).promise()
     console.log({ quotient })
     ++batchMultiplier
     --quotient
   }
 }
 
-/* Upload the remaining items (less than 25) */
-docClient.batchWrite(
-  {
-    RequestItems: {
-      YOUR_TABLE_NAME: seedData.slice(seedData.length - remainder),
+/* Upload the remaining items (less than 25) */]
+if(remainder > 0){
+  await docClient.batchWrite(
+    {
+      RequestItems: {
+        YOUR_TABLE_NAME: seedData.slice(seedData.length - remainder),
+      },
     },
-  },
-  (err, data) => {
-    if (err) {
-      console.log('something went wrong...')
-    } else {
-      console.log('yay...the remainder uploaded!')
+    (err, data) => {
+      if (err) {
+        console.log('something went wrong...')
+      } else {
+        console.log('yay...the remainder uploaded!')
+      }
     }
-  }
-)
+  ).promise()
+}
 ```


### PR DESCRIPTION
- Await batchWrite requests:
Turn into a promise and make sure it is awaited
- Check length of remainder:
No longer execute the last batchWrite request if remainder is 0.
This means all requests coming from seedData have been executed already.
Before when you had eg. seedData with length = 100 -> 4 batchWrite requests.
Then remainder is 0 and it would fail because slicing the seedData: `seedData.slice(seedData.length - remainder)` gives an array of length 0. 
Meaning `RequestItems` becomes an empty array which is not permitted.